### PR TITLE
Update node version for prettier >= 3.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine3.9
+FROM node:18.18.2-bookworm
 RUN apk update && apk upgrade && apk add --no-cache bash git openssh
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2020 Conrad Großer
-Copyright (c) 2020 Tim van Mourik
+Copyright (c) 2020 CTcue
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -44,15 +44,17 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Prettify code
-        uses: TimVanMourik/pretty-quick-gh-action@v1.0
+        uses: CTcue/pretty-quick-gh-action@v1.4
         with:
-          prettier_version: 2.2.1
-          pretty_quick_version: 3.1.0
+          prettier_version: 3.3.2
+          pretty_quick_version: 4.0.0
           # This part is also where you can pass other options, for example:
-          prettier_options: --write **/*.{js,md}
+          prettier_options: --write **/*.{ts,md}
           root: .
 ```
 
-## Issues
+## Update action
 
-Please report all bugs and feature request using the [GitHub issues function](https://github.com/TimVanMourik/pretty-quick-gh-action/issues/new). Thanks!
+* Create PR and review
+* Once merged add a new version tag
+* Reference new version in workflows


### PR DESCRIPTION
Prettier removed support for node versions < 14

This PR updates the Dockerfile so we make use of a more recent node version.